### PR TITLE
ClojureScript Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,23 @@
 language: clojure
 
-script: lein test-clj
+script: lein test-$CLJ
 
 before_install:
   - git submodule update --init --recursive
   - yes | sudo lein upgrade
 
-jdk:
-  - openjdk6
-  - openjdk7
-  - oraclejdk7
-  - oraclejdk8
+matrix:
+  include:
+  - jdk: openjdk6
+    env: CLJ=clj
+  - jdk: openjdk7
+    env: CLJ=clj
+  - jdk: oraclejdk7
+    env: CLJ=clj
+  - jdk: oraclejdk8
+    env: CLJ=clj
+  - jdk: oraclejdk8
+    env: CLJ=cljs
 
 sudo: required
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
-1.5.0
-=====
+2.0.0 (2016)
+============
+* Rename to cljstache
+* Add support for Clojure 1.7 - 1.9
+* Remove support for Clojure < 1.7
+
+1.5.0 (2014-05-07)
+==================
 * Handle path whitespace consistently.
 
 1.4.0 (2014-05-05)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 * Rename to cljstache
 * Add support for Clojure 1.7 - 1.9
 * Remove support for Clojure < 1.7
+* Add support for ClojureScript 1.8 - 1.9
 
 1.5.0 (2014-05-07)
 ==================

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ git submodule update --init
 And run them against all supported Clojure versions:
 
 ```
-lein all test
+lein test-all
 ```
 
 Requirements

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Cljstache
 Logic-less {{ [mustache](http://mustache.github.com) }} templates for Clojure[Script].
 
 Compliant with the [Mustache spec](http://github.com/mustache/spec)
-, including lambdas.
+, including lambdas (on jvm only.)
 
 Forked from [clostache](https://github.com/fhd/clostache) and updated to be compatible with ClojureScript.
 
@@ -17,10 +17,10 @@ The easiest way to use Cljstache in your project is via
 
 Add to project.clj
 
-# TODO: clojars badge
 ```clj
-[cljstache "1.6.0-SNAPSHOT"]
+[cljstache "2.0.0-SNAPSHOT"]
 ```
+<!-- TODO: Add clojars badge -->
 
 This is how you use Cljstache:
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 Cljstache
 =========
-Logic-less {{ [mustache](http://mustache.github.com) }} templates for Clojure[Script].
+{{ [mustache](http://mustache.github.com) }} templates for Clojure[Script].
 
 Compliant with the [Mustache spec](http://github.com/mustache/spec)
-, including lambdas (on jvm only.)
+, including lambdas (jvm only)
 
 Forked from [clostache](https://github.com/fhd/clostache) and updated to be compatible with ClojureScript.
 
@@ -381,6 +381,7 @@ Requirements
 ------------
 
 As steadyhash uses Clojure's reader conditionals, steadyhash is dependent on both Clojure 1.7 and Leiningen 2.5.2 or later.
+Java 8 or greater is required to run the clojurescript tests (using Nashorn.)
 
 License
 -------

--- a/project.clj
+++ b/project.clj
@@ -11,8 +11,7 @@
 
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
                                   [org.clojure/data.json "0.1.2"]
-                                  [jline/jline "0.9.94"]
-                                  [org.mozilla/rhino "1.7.7"]]
+                                  [jline/jline "0.9.94"]]
                    :resource-paths ["test-resources"]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
@@ -28,7 +27,7 @@
   :aliases {"with-clj" ["with-profile" "dev:dev,1.7:dev,1.8:dev,1.9"]
             "with-cljs" ["with-profile" "cljs:cljs1.8"]
             "test-clj" ["with-clj" "test"]
-            "test-cljs" ["with-cljs" "doo" "rhino" "test" "once"]
+            "test-cljs" ["with-cljs" "doo" "nashorn" "test" "once"]
             "test-all" ["do" "clean," "test-clj," "test-cljs"]
             "deploy" ["do" "clean," "deploy" "clojars"]}
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cljstache "1.6.0-SNAPSHOT"
+(defproject cljstache "2.0.0-SNAPSHOT"
   :min-lein-version "2.5.2"
   :description "{{ mustache }} for Clojure[Script]"
   :url "http://github.com/fhd/clostache"
@@ -11,7 +11,8 @@
 
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
                                   [org.clojure/data.json "0.1.2"]
-                                  [jline/jline "0.9.94"]]
+                                  [jline/jline "0.9.94"]
+                                  [org.mozilla/rhino "1.7.7"]]
                    :resource-paths ["test-resources"]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}

--- a/project.clj
+++ b/project.clj
@@ -16,13 +16,17 @@
                    :resource-paths ["test-resources"]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
-             :1.9 {:dependencies [[org.clojure/clojure "1.9.0-alpha10"]]}
-             :cljs {:dependencies [[org.clojure/clojurescript "1.8.51"]]
-                    :plugins [[lein-cljsbuild "1.1.3"]
-                              [lein-doo "0.1.6"]]}}
+             :1.9 {:dependencies [[org.clojure/clojure "1.9.0-alpha12"]]}
+             :cljs1.8 {:dependencies [[org.clojure/clojurescript "1.8.51"]]
+                       :plugins [[lein-cljsbuild "1.1.3"]
+                                 [lein-doo "0.1.6"]]}
+             :cljs {:dependencies [[org.clojure/clojure "1.9.0-alpha12"]
+                                   [org.clojure/clojurescript "1.9.229"]]
+                       :plugins [[lein-cljsbuild "1.1.3"]
+                                 [lein-doo "0.1.6"]]}}
 
   :aliases {"with-clj" ["with-profile" "dev:dev,1.7:dev,1.8:dev,1.9"]
-            "with-cljs" ["with-profile" "cljs"]
+            "with-cljs" ["with-profile" "cljs:cljs1.8"]
             "test-clj" ["with-clj" "test"]
             "test-cljs" ["with-cljs" "doo" "rhino" "test" "once"]
             "test-all" ["do" "clean," "test-clj," "test-cljs"]
@@ -33,6 +37,8 @@
   :doo {:paths {:rhino "lein run -m org.mozilla.javascript.tools.shell.Main"}}
 
   :global-vars {*warn-on-reflection* true}
+
+  :clean-targets [:target-path "out"]
 
   :cljsbuild {:builds
               {:test {:source-paths ["src" "test"]

--- a/src/cljstache/core.cljc
+++ b/src/cljstache/core.cljc
@@ -54,9 +54,9 @@
            :match-end (.end match)}))))
   #?(:cljs
      ([[m s] offset]
-      (if-let [match (.exec m (subs s offset))]
+      (when-let [match (.exec m (subs s offset))]
         {:match-start (+ (.-index match) offset)
-         :match-end (+ (.-index match) (count match) offset)}))))
+         :match-end (+ (.-index match) (-> match first count) offset)}))))
 
 (defrecord Section [name body start end inverted])
 

--- a/src/cljstache/core.cljc
+++ b/src/cljstache/core.cljc
@@ -467,7 +467,8 @@
 
 #?(:clj
    (defn render-resource
-     "Renders a resource located on the classpath"
+     "Renders a resource located on the classpath.
+      Only available on the JVM"
      ([^String path]
       (render (slurp (io/resource path)) {}))
      ([^String path data]

--- a/test/cljstache/core_test.cljc
+++ b/test/cljstache/core_test.cljc
@@ -35,11 +35,16 @@
 
 (deftest matcher-find-test
   (is (= {:match-start 2
-          :match-end 3}
-         (cs/matcher-find (re-matcher #"\d" "ab1def"))))
+          :match-end 7}
+         (cs/matcher-find (re-matcher #"\d+" "ab12345def"))))
   (is (= {:match-start 6
           :match-end 7}
-         (cs/matcher-find (re-matcher #"\d" "ab1def4") 3))))
+         (cs/matcher-find (re-matcher #"\d" "ab1def4") 3)))
+  (is (= {:match-start 5
+          :match-end 12}
+         (cs/matcher-find
+          (#'cs/delim-matcher (#'cs/escape-regex "<%") (#'cs/escape-regex "%>")
+                              "asdf <%foo%> lkhasdf")))))
 
 (deftest str-replace-test
   (is (= "password" (#'cs/str-replace "pa55word" "\\d" "s")))
@@ -75,6 +80,13 @@
     (testing "sb-insert"
       (is (= "abc123def"
              (-> (b) (#'cs/sb-insert 3 "123") (#'cs/sb->str)))))))
+
+
+
+(deftest process-set-delimiters-test
+  (testing "Correctly replaces custom delimiters"
+    (is (= ["Hello, {{name}}" {:name "Felix"}]
+           (#'cs/process-set-delimiters "{{=<% %>=}}Hello, <%name%>" {:name "Felix"})))))
 
 ;; Render Tests
 

--- a/test/cljstache/core_test.cljc
+++ b/test/cljstache/core_test.cljc
@@ -180,24 +180,22 @@
 (deftest test-render-inverted-boolean-false
   (is (= "Hello, Felix" (render "Hello, {{^condition}}Felix{{/condition}}"
                                 {:condition false}))))
-;; Currently fails for cljs
+
 (deftest test-render-with-delimiters
   (is (= "Hello, Felix" (render "{{=<% %>=}}Hello, <%name%>" {:name "Felix"}))))
 
-;; Currently fails for cljs
+
 (deftest test-render-with-regex-delimiters
   (is (= "Hello, Felix" (render "{{=[ ]=}}Hello, [name]" {:name "Felix"}))))
 
-;; Currently fails for cljs
+
 (deftest test-render-with-delimiters-changed-twice
   (is (= "Hello, Felix" (render "{{=[ ]=}}[greeting], [=<% %>=]<%name%>"
                                 {:greeting "Hello" :name "Felix"}))))
 
-;; Out of memory for cljs
-#?(:clj
-   (deftest test-render-tag-with-dotted-name-like-section
-     (is (= "Hello, Felix" (render "Hello, {{felix.name}}"
-                                   {:felix {:name "Felix"}})))))
+(deftest test-render-tag-with-dotted-name-like-section
+  (is (= "Hello, Felix" (render "Hello, {{felix.name}}"
+                                {:felix {:name "Felix"}}))))
 
 (deftest test-render-lambda
   (is (= "Hello, Felix" (render "Hello, {{name}}"
@@ -237,10 +235,8 @@
     (is (= "" (render "{{^l}}X{{/l}}" {:l l}))))
   (is (= "X" (render "{{^l}}X{{/l}}" {:l (sorted-set)}))))
 
-;; Out of Memory for cljs
-#?(:clj
-   (deftest test-path-whitespace-handled-consistently
-     (is (= (render "{{a}}" {:a "value"}) "value"))
-     (is (= (render "{{ a }}" {:a "value"}) "value"))
-     (is (= (render "{{a.b}}" {:a {:b "value"}}) "value"))
-     (is (= (render "{{ a.b }}" {:a {:b "value"}}) "value"))))
+(deftest test-path-whitespace-handled-consistently
+  (is (= (render "{{a}}" {:a "value"}) "value"))
+  (is (= (render "{{ a }}" {:a "value"}) "value"))
+  (is (= (render "{{a.b}}" {:a {:b "value"}}) "value"))
+  (is (= (render "{{ a.b }}" {:a {:b "value"}}) "value")))

--- a/test/cljstache/core_test.cljc
+++ b/test/cljstache/core_test.cljc
@@ -1,8 +1,82 @@
-(ns cljstache.test-parser
+(ns cljstache.core-test
   (:require
    #?(:clj  [clojure.test :refer :all]
       :cljs [cljs.test :refer-macros [deftest testing is]])
-   [cljstache.core :refer [render] :as cs]))
+   #?(:clj [cljstache.core :as cs :refer [render render-resource]])
+   #?(:cljs [cljstache.core :as cs :refer [render re-matcher re-find re-groups]])))
+
+;; cljs compatibility tests
+
+(deftest test-re-quote-replacement
+  (is (= "$abc" (#'cs/str-replace "foo" "foo" (cs/re-quote-replacement "$abc"))))
+  (is (= "fabc\\abc"
+         (#'cs/str-replace "foo" "oo" (cs/re-quote-replacement "abc\\abc"))))
+  (is (= "f$abc\\abc$"
+         (#'cs/str-replace "foo" "oo" (cs/re-quote-replacement "$abc\\abc$")))))
+
+(deftest re-find-test
+  (is (= "1" (re-find (re-pattern "\\d") "ab1def")))
+  (is (= "1" (re-find (re-matcher #"\d" "ab1def"))))
+  (is (= ["1" "1"] (re-find (re-matcher #"(\d)" "ab1de3f"))))
+  (is (= ["<%foo%>" "<%foo%>"]
+         (re-find
+          (#'cs/delim-matcher (#'cs/escape-regex "<%") (#'cs/escape-regex "%>")
+                              "asdf <%foo%> lkhasdf"))))
+  (is (= ["{{=<% %>=}}" "<%" "%>"]
+         (#'cs/find-custom-delimiters
+          "\\{\\{"
+          "\\}\\}"
+          "{{=<% %>=}}Hello, <%name%>"))))
+
+(deftest re-groups-test
+  (let [matcher (re-matcher #"(\d)" "ab1cd3")
+        match (re-find matcher)]
+    (is (= ["1" "1"] (vec (re-groups matcher))))))
+
+(deftest matcher-find-test
+  (is (= {:match-start 2
+          :match-end 3}
+         (cs/matcher-find (re-matcher #"\d" "ab1def"))))
+  (is (= {:match-start 6
+          :match-end 7}
+         (cs/matcher-find (re-matcher #"\d" "ab1def4") 3))))
+
+(deftest str-replace-test
+  (is (= "password" (#'cs/str-replace "pa55word" "\\d" "s")))
+  (is (= "password" (#'cs/str-replace "pasword" "s" "ss"))))
+
+(deftest replace-all-test
+  (testing "escape-html"
+   (is (= "&lt;html&gt;&amp;&quot;"
+          (#'cs/escape-html "<html>&\""))))
+  (testing "indent-partial"
+    (is (= "a\n-->b\n-->c\n-->d"
+           (#'cs/indent-partial "a\nb\nc\nd" "-->"))))
+  (testing "escape-regex"
+    (is (= "\\\\\\{\\}\\[\\]\\(\\)\\.\\?\\^\\+\\-\\|="
+           (#'cs/escape-regex "\\{}[]().?^+-|="))))
+  (testing "unescape-regex"
+    (is (= "{}[]().?^+-|=\\"
+         (#'cs/unescape-regex "\\{\\}\\[\\]\\(\\)\\.\\?\\^\\+\\-\\|=\\")))))
+
+(deftest stringbuilder-test
+  (let [b (fn [] (#'cs/->stringbuilder "abcdef"))]
+    (testing "sb->str"
+      (is (= "abcdef" (#'cs/sb->str (b)))))
+    (testing "sb-replace"
+      (is (= "abcDDDef"
+             (-> (b) (#'cs/sb-replace 3 4 "DDD") (#'cs/sb->str)))))
+    (testing "sb-delete"
+      (is (= "abcef"
+             (-> (b) (#'cs/sb-delete 3 4) (#'cs/sb->str)))))
+    (testing "sb-append"
+      (is (= "abcdefghijk"
+             (-> (b) (#'cs/sb-append "ghijk") (#'cs/sb->str)))))
+    (testing "sb-insert"
+      (is (= "abc123def"
+             (-> (b) (#'cs/sb-insert 3 "123") (#'cs/sb->str)))))))
+
+;; Render Tests
 
 (deftest test-render-simple
   (is (= "Hello, Felix" (render "Hello, {{name}}" {:name "Felix"}))))
@@ -128,7 +202,7 @@
 ;; Not implemented for cljs
 #?(:clj
    (deftest test-render-resource-template
-     (is (= "Hello, Felix" (cs/render-resource "templates/hello.mustache" {:name "Felix"})))))
+     (is (= "Hello, Felix" (render-resource "templates/hello.mustache" {:name "Felix"})))))
 
 (deftest test-render-with-partial
   (is (= "Hi, Felix" (render "Hi, {{>name}}" {:n "Felix"} {:name "{{n}}"}))))

--- a/test/cljstache/mustache_spec_test.cljc
+++ b/test/cljstache/mustache_spec_test.cljc
@@ -2,6 +2,8 @@
   "Test against the [Mustache spec](http://github.com/mustache/spec)"
   (:require [cljstache.core :refer [render]]
             [clojure.string :as str]
+            ;; #?(:cljs [cljs.tools.reader :refer [read-string]])
+            ;; #?(:cljs [cljs.js :refer [empty-state js-eval]])
             #?(:clj [clojure.test :refer :all])
             #?(:cljs [cljs.test :refer-macros [deftest testing is]])
             #?(:clj [clojure.data.json :as json]))
@@ -30,7 +32,15 @@
 (defn- extract-lambdas [data]
   (update-lambda-in data #(:clojure %)))
 
-#?(:cljs (def load-string identity))
+#?(:cljs (defn load-string [s] s
+         #_(:value
+            (when-let [f (read-string s)]
+              (cljs.js/eval (cljs.js/empty-state)
+                            f
+                            {:eval js-eval
+                             :source-map true
+                             :context :expr}
+                            (fn [x] (println x) x))))))
 
 (defn- load-lambdas [data]
   (update-lambda-in data #(load-string %)))
@@ -53,36 +63,25 @@
   (doseq [spec-test (spec-tests spec)]
     (run-spec-test spec-test)))
 
-;; OutOfMemoryError in cljs
-#?(:clj
-   (deftest test-comments
-     (run-spec-tests "comments")))
+(deftest test-comments
+  (run-spec-tests "comments"))
 
-;; Currently fails in cljs
 (deftest test-delimiters
   (run-spec-tests "delimiters"))
 
-;; OutOfMemoryError in cljs
-#?(:clj
-   (deftest test-interpolation
-     (run-spec-tests "interpolation")))
+(deftest test-interpolation
+  (run-spec-tests "interpolation"))
 
-;; OutOfMemoryError in cljs
-#?(:clj
-   (deftest test-sections
-     (run-spec-tests "sections")))
+(deftest test-sections
+  (run-spec-tests "sections"))
 
-;; OutOfMemoryError in cljs
-#?(:clj
-   (deftest test-inverted
-     (run-spec-tests "inverted")))
+(deftest test-inverted
+  (run-spec-tests "inverted"))
 
-;; Currently fails in cljs
 (deftest test-partials
   (run-spec-tests "partials"))
 
-;; Lambdas are not supported in Clojurescript due to lack of `eval'
-;; http://blog.fogus.me/2011/07/29/compiling-clojure-to-javascript-pt-2-why-no-eval/
+;; Unable to load the labdas in cljs due to eval issues
 #?(:clj
    (deftest test-lambdas
      (run-spec-tests "~lambdas")))

--- a/test/cljstache/mustache_spec_test.cljc
+++ b/test/cljstache/mustache_spec_test.cljc
@@ -1,10 +1,11 @@
-(ns cljstache.test-specs
+(ns cljstache.mustache-spec-test
+  "Test against the [Mustache spec](http://github.com/mustache/spec)"
   (:require [cljstache.core :refer [render]]
             [clojure.string :as str]
             #?(:clj [clojure.test :refer :all])
             #?(:cljs [cljs.test :refer-macros [deftest testing is]])
             #?(:clj [clojure.data.json :as json]))
-  #?(:cljs (:require-macros [cljstache.test-specs :refer [load-specs]])))
+  #?(:cljs (:require-macros [cljstache.mustache-spec-test :refer [load-specs]])))
 
 ;; We load the specs at compile time via macro
 ;; for clojurescript compatibility

--- a/test/cljstache/runner.cljs
+++ b/test/cljstache/runner.cljs
@@ -1,8 +1,8 @@
 (ns cljstache.runner
   "A stub namespace to run cljs tests using doo"
   (:require [doo.runner :refer-macros [doo-tests]]
-            [cljstache.test-parser]
-            [cljstache.test-specs]))
+            [cljstache.core-test]
+            [cljstache.mustache-spec-test]))
 
-(doo-tests 'cljstache.test-parser
-           'cljstache.test-specs)
+(doo-tests 'cljstache.core-test
+           'cljstache.mustache-spec-test)

--- a/test/cljstache/test_parser.cljc
+++ b/test/cljstache/test_parser.cljc
@@ -94,20 +94,24 @@
 (deftest test-render-inverted-boolean-false
   (is (= "Hello, Felix" (render "Hello, {{^condition}}Felix{{/condition}}"
                                 {:condition false}))))
-
+;; Currently fails for cljs
 (deftest test-render-with-delimiters
   (is (= "Hello, Felix" (render "{{=<% %>=}}Hello, <%name%>" {:name "Felix"}))))
 
+;; Currently fails for cljs
 (deftest test-render-with-regex-delimiters
   (is (= "Hello, Felix" (render "{{=[ ]=}}Hello, [name]" {:name "Felix"}))))
 
+;; Currently fails for cljs
 (deftest test-render-with-delimiters-changed-twice
   (is (= "Hello, Felix" (render "{{=[ ]=}}[greeting], [=<% %>=]<%name%>"
                                 {:greeting "Hello" :name "Felix"}))))
 
-(deftest test-render-tag-with-dotted-name-like-section
-  (is (= "Hello, Felix" (render "Hello, {{felix.name}}"
-                                {:felix {:name "Felix"}}))))
+;; Out of memory for cljs
+#?(:clj
+   (deftest test-render-tag-with-dotted-name-like-section
+     (is (= "Hello, Felix" (render "Hello, {{felix.name}}"
+                                   {:felix {:name "Felix"}})))))
 
 (deftest test-render-lambda
   (is (= "Hello, Felix" (render "Hello, {{name}}"
@@ -121,6 +125,7 @@
                  {:people [{:name "Tom"}, {:name "Bob"}]
                   :upper (fn [text] (fn [render-fn] (clojure.string/upper-case (render-fn text))))}))))
 
+;; Not implemented for cljs
 #?(:clj
    (deftest test-render-resource-template
      (is (= "Hello, Felix" (cs/render-resource "templates/hello.mustache" {:name "Felix"})))))
@@ -146,8 +151,10 @@
     (is (= "" (render "{{^l}}X{{/l}}" {:l l}))))
   (is (= "X" (render "{{^l}}X{{/l}}" {:l (sorted-set)}))))
 
-(deftest test-path-whitespace-handled-consistently
-  (is (= (render "{{a}}" {:a "value"}) "value"))
-  (is (= (render "{{ a }}" {:a "value"}) "value"))
-  (is (= (render "{{a.b}}" {:a {:b "value"}}) "value"))
-  (is (= (render "{{ a.b }}" {:a {:b "value"}}) "value")))
+;; Out of Memory for cljs
+#?(:clj
+   (deftest test-path-whitespace-handled-consistently
+     (is (= (render "{{a}}" {:a "value"}) "value"))
+     (is (= (render "{{ a }}" {:a "value"}) "value"))
+     (is (= (render "{{a.b}}" {:a {:b "value"}}) "value"))
+     (is (= (render "{{ a.b }}" {:a {:b "value"}}) "value"))))


### PR DESCRIPTION
Cljstache ported to ClojureScript.

Required some awkward hacks of code with java interop, particularly around StringBulder and Regex.
This could still use a little refactoring, but it works!