### PR TITLE
Just ignore invalid tags

### DIFF
--- a/src/cljstache/core.cljc
+++ b/src/cljstache/core.cljc
@@ -265,14 +265,14 @@
 (defn- find-section-start-tag
   "Find the next section start tag, starting to search at index."
   [^String template index]
-  (next-index template #"\{\{[#\^]" index))
+  (next-index template #"\{\{[#\^][^\}]*\}\}" index))
 
 (defn- find-section-end-tag
   "Find the matching end tag for a section at the specified level,
    starting to search at index."
   [^String template ^long index ^long level]
   (let [next-start (find-section-start-tag template index)
-        next-end (.indexOf ^String template "{{/" index)]
+        next-end (next-index template #"\{\{/[^\}]*\}\}" index)]
     (if (= next-end -1)
       -1
       (if (and (not= next-start -1) (< next-start next-end))

--- a/test/cljstache/core_test.cljc
+++ b/test/cljstache/core_test.cljc
@@ -244,3 +244,9 @@
   (is (= (render "{{ a }}" {:a "value"}) "value"))
   (is (= (render "{{a.b}}" {:a {:b "value"}}) "value"))
   (is (= (render "{{ a.b }}" {:a {:b "value"}}) "value")))
+
+(deftest test-ignore-invalid-tag
+  (is (= (render "{{#a}}" {:a ["value"]}) ""))
+  (is (= (render "{{/a}}" {:a ["value"]}) ""))
+  (is (= (render "{{#a" {:a ["value"]}) "{{#a"))
+  (is (= (render "{{#a}}{{/" {:a ["value"]}) "{{/")))


### PR DESCRIPTION
I encountered unexpected exception.

```clj
(render "{{#a}}{{a}}{{/" {:a ["value"]})
;; => java.lang.StringIndexOutOfBoundsException
```

I thought `{{/` is not a tag. So, I fixed find section tag behavior.

I know, other mustache implementations are throw exception, that says "unclosed/unpened section". But, that's difficult to fix correctly with current implementaion.