### PR TITLE
Fix not to delete extra newlines after 2nd or later sections

### DIFF
--- a/test/cljstache/core_test.cljc
+++ b/test/cljstache/core_test.cljc
@@ -225,6 +225,16 @@
   (is (= "Hello, Felix" (render "Hello, {{felix.name}}"
                                 {:felix {:name "Felix"}}))))
 
+(deftest test-render-multiple-sections
+  (is (= "Hello\n\nFelix\n\nFelix\n\n!"
+         (render "Hello\n\n{{#felix}}{{name}}{{/felix}}\n\n{{#felix}}{{name}}{{/felix}}\n\n!" {:felix {:name "Felix"}})))
+  (is (= "Hello\n\nFelix\n\nFelix\n\n!"
+         (render "Hello\n\n{{#felix}}\n{{name}}\n{{/felix}}\n\n{{#felix}}{{name}}{{/felix}}\n\n!" {:felix {:name "Felix"}})))
+  (is (= "Hello\n\nFelix\n\nFelix\n\n!"
+         (render "Hello\n\n{{#felix}}{{name}}{{/felix}}\n\n{{#felix}}\n{{name}}\n{{/felix}}\n\n!" {:felix {:name "Felix"}})))
+  (is (= "Hello\n\nFelix\n\nFelix\n\n!"
+         (render "Hello\n\n{{#felix}}\n{{name}}\n{{/felix}}\n\n{{#felix}}\n{{name}}\n{{/felix}}\n\n!" {:felix {:name "Felix"}}))))
+
 (deftest test-render-lambda
   (is (= "Hello, Felix" (render "Hello, {{name}}"
                                 {:name (fn [] "Felix")}))))


### PR DESCRIPTION
## Test code

```clj
(-> (clojure.string/join "\n" ["Hello"
                               ""
                               "{{#felix}}"
                               "{{name}}"
                               "{{/felix}}"
                               ""
                               "{{#felix}}"
                               "{{name}}"
                               "{{/felix}}"
                               ""
                               "!!"])
    (render {:felix {:name "Felix"}}))
```

## Expected behavior

The result should end with `\n\n!!` such as `"Hello\n\nFelix\n\nFelix\n\n!!"`.

## Actual behavior

The newline after second section has removed such as `"Hello\n\nFelix\n\nFelix\n!!"`.
This is caused `cljstache.core/join-standalone-tags` is called for the number of sections.