### PR TITLE
Make the library compatible with babashka interpreter

### DIFF
--- a/src/cljstache/core.cljc
+++ b/src/cljstache/core.cljc
@@ -51,9 +51,8 @@
   #?(:clj
      ([^java.util.regex.Matcher m offset]
       (when (.find m offset)
-        (let [match (.toMatchResult m)]
-          {:match-start (.start match)
-           :match-end (.end match)}))))
+        {:match-start (.start m)
+         :match-end (.end m)})))
   #?(:cljs
      ([[m s] offset]
       (when-let [match (.exec m (subs s offset))]


### PR DESCRIPTION
There is no need to use the .toMatchResult method to get the matching
start and end. Those methods are alreay available in the Matcher
class. They return the exact same values and they don't need to use an
inner class. This access is not allowed when using the babashka
Clojure(Script) interpreter.

Babashka is statically compiled using GraalVM, and GraalVM is fairly
restrictive with access to classes. Unless you specifically list them
in the build configuration, the access is denied. Potentially even it
can completely strip the classes out, if it thinks they are not
used (it performs some static analysis to determine it, but it can
fail depending on how the classes are used).